### PR TITLE
Remove deprecated duplicate macro exports

### DIFF
--- a/rust/src/enums.rs
+++ b/rust/src/enums.rs
@@ -1,8 +1,4 @@
 #[macro_export]
-macro_rules! _probor_pattern {
-    ($x:pat) => { $x }
-}
-#[macro_export]
 macro_rules! _probor_enum_pattern {
     ($name:ident $variant:ident) => {
         $name::$variant


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/50143 for more details.